### PR TITLE
Update run instructions and KuCoin error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ conda activate algo
 ## Running
 
 ```bash
-python -m src.run --mode=backtest
+PYTHONPATH=src python -m trading.main --mode backtest
 ```
 
 ## Tests

--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ conda activate algo
 ```bash
 PYTHONPATH=src python -m trading.main --mode backtest
 ```
+If you run the application from another directory, set `CONFIG_PATH` to the
+location of your `config.yaml` so the loader can find it:
+```bash
+CONFIG_PATH=/path/to/config.yaml PYTHONPATH=src python -m trading.main --mode backtest
+```
 
 ## Tests
 

--- a/src/trading/config.py
+++ b/src/trading/config.py
@@ -13,12 +13,22 @@ class Config:
     kucoin: dict
 
 
-def load_config(config_path: str = "config.yaml") -> Config:
-    """Load configuration from YAML and environment variables."""
+def load_config(config_path: str | None = None) -> Config:
+    """Load configuration from YAML and environment variables.
+
+    The config path can be provided as an argument or via the ``CONFIG_PATH``
+    environment variable. If the file is not found relative to the current
+    working directory, the loader also checks the repository root so the
+    application can be executed from any location.
+    """
     load_dotenv()
-    path = Path(config_path)
+    path = Path(config_path or os.getenv("CONFIG_PATH", "config.yaml"))
     if not path.exists():
-        raise FileNotFoundError(f"Config file {config_path} missing")
+        repo_path = Path(__file__).resolve().parents[2] / path.name
+        if repo_path.exists():
+            path = repo_path
+        else:
+            raise FileNotFoundError(f"Config file {path} missing")
     data = yaml.safe_load(path.read_text())
     mode = os.getenv("MODE", "backtest")
     kucoin = {

--- a/src/trading/exchange/kucoin.py
+++ b/src/trading/exchange/kucoin.py
@@ -18,11 +18,15 @@ class KucoinClient(BaseExchange):
         self.base_url = base_url.rstrip("/")
 
     async def get_ws_token(self) -> str:
+        """Retrieve websocket token for public market streams."""
         url = f"{self.base_url}/api/v1/bullet-public"
-        async with aiohttp.ClientSession() as session:
-            async with session.post(url) as resp:
-                data = await resp.json()
-                return data["data"]["token"]
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(url) as resp:
+                    data = await resp.json()
+                    return data["data"]["token"]
+        except aiohttp.ClientError as exc:
+            raise ConnectionError(f"Failed to obtain KuCoin token: {exc}") from exc
 
     async def place_order(self, symbol: str, side: str, size: float, price: Optional[float] = None) -> dict:
         url = f"{self.base_url}/api/v1/orders"


### PR DESCRIPTION
## Summary
- fix README run command example
- handle aiohttp errors when getting KuCoin token

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889ee040590832da7807f9cde4cd53f