### PR TITLE
Add Replit deployment config

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,1 @@
+run = "bash start.sh"

--- a/README.md
+++ b/README.md
@@ -60,3 +60,9 @@ Run all unit tests with:
 ```bash
 pytest -q tests
 ```
+
+## Replit Deployment
+
+Launch the repository on Replit to automatically install dependencies and start the trading engine alongside the dashboard. When the repl loads, open the webview URL to monitor performance in real time.
+
+

--- a/replit.nix
+++ b/replit.nix
@@ -1,0 +1,7 @@
+{ pkgs }: {
+  deps = [
+    pkgs.bashInteractive
+    pkgs.python311
+    pkgs.python311Packages.pip
+  ];
+}

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+python -m trading.main --mode backtest &
+uvicorn trading.dashboard:app --host 0.0.0.0 --port 8000


### PR DESCRIPTION
## Summary
- add `.replit`, `replit.nix` and `start.sh` to launch the trading engine and dashboard on Replit
- document how to deploy on Replit in the README

## Testing
- `pytest -q`
- `flake8 .`


------
https://chatgpt.com/codex/tasks/task_e_688a8341ecb0832db469cc547c42f31e